### PR TITLE
Update 10.4.9: geth v1.10.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.1 as geth
+FROM ethereum/client-go:v1.10.4 as geth
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:edge

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "goerli-geth.avado.dnp.dappnode.eth",
-  "version": "10.4.8",
-  "upstream": "1.10.1",
+  "version": "10.4.9",
+  "upstream": "v1.10.4",
   "autoupdate": true,
   "description": "This package provides a Geth Ethereum client that is configured to sync the Görli Testnet. The Görli Testnet is the first proof-of-authority cross-client testnet. A testnet can be useful when developing dapps. If you’re a developer - this package can be very useful for you.",
   "type": "library",
@@ -19,9 +19,9 @@
       "8547:8547"
     ],
     "restart": "always",
-    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.8.tar.xz",
-    "hash": "/ipfs/QmWkRVABZcJeh8tdQGXsoTKMdQ56eEL9r5na7rT4GWgqEU",
-    "size": 17583676,
+    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.9.tar.xz",
+    "hash": "/ipfs/QmcH9TATwADrRPmvkS9TMjLGD55r5mNDJ8oRuz1jVYzQKb",
+    "size": 17768304,
     "environment": [
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   goerli-geth.avado.dnp.dappnode.eth:
-    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.8'
+    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.9'
     build: ./build
     volumes:
       - 'goerli:/goerli'

--- a/releases.json
+++ b/releases.json
@@ -47,5 +47,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Fri, 26 Mar 2021 23:45:39 GMT"
     }
+  },
+  "10.4.9": {
+    "hash": "/ipfs/QmSoywdtpsV7MXRmWrbYsgZEXwarLapAyK6JGNof2DpJmG",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 24 Jun 2021 21:11:30 GMT"
+    }
   }
 }


### PR DESCRIPTION
Manifest hash : /ipfs/QmSoywdtpsV7MXRmWrbYsgZEXwarLapAyK6JGNof2DpJmG

https://github.com/ethereum/go-ethereum/releases/tag/v1.10.4

Geth v1.10.4 is a feature release and adds compatibility with the upcoming London hard fork.
Enables snap sync by default