### PR TITLE
Update 10.4.11: geth v1.10.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.5 as geth
+FROM ethereum/client-go:v1.10.6 as geth
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:edge

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "goerli-geth.avado.dnp.dappnode.eth",
-  "version": "10.4.10",
-  "upstream": "v1.10.5",
+  "version": "10.4.11",
+  "upstream": "v1.10.6",
   "autoupdate": true,
   "description": "This package provides a Geth Ethereum client that is configured to sync the Görli Testnet. The Görli Testnet is the first proof-of-authority cross-client testnet. A testnet can be useful when developing dapps. If you’re a developer - this package can be very useful for you.",
   "type": "library",
@@ -19,9 +19,9 @@
       "8547:8547"
     ],
     "restart": "always",
-    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.10.tar.xz",
-    "hash": "/ipfs/QmPTFzpvink7JBjHPfHgBFGnf3yhF8jTwSyDA14uapSvEp",
-    "size": 17550508,
+    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.11.tar.xz",
+    "hash": "/ipfs/QmTpMhkUu1jEhxcvtnvUNg2wKTZ8BK9MqzYkAA75pDVxLz",
+    "size": 17548556,
     "environment": [
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   goerli-geth.avado.dnp.dappnode.eth:
-    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.10'
+    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.11'
     build: ./build
     volumes:
       - 'goerli:/goerli'

--- a/releases.json
+++ b/releases.json
@@ -61,5 +61,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 14 Jul 2021 14:01:20 GMT"
     }
+  },
+  "10.4.11": {
+    "hash": "/ipfs/QmdJ3ydEL7BZzHtjafvZgTS9dpyjCV8E794W8KQtXP5ATT",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 22 Jul 2021 18:08:36 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/releases/tag/v1.10.6

Manifest hash : /ipfs/QmdJ3ydEL7BZzHtjafvZgTS9dpyjCV8E794W8KQtXP5ATT
http://my.dappnode/#/installer/%2Fipfs%2FQmdJ3ydEL7BZzHtjafvZgTS9dpyjCV8E794W8KQtXP5ATT
