### PR TITLE
Update 10.4.16: geth v1.10.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.8 as geth
+FROM ethereum/client-go:v1.10.9 as geth
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:edge

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "goerli-geth.avado.dnp.dappnode.eth",
-  "version": "10.4.15",
-  "upstream": "v1.10.8",
+  "version": "10.4.16",
+  "upstream": "v1.10.9",
   "autoupdate": true,
   "description": "This package provides a Geth Ethereum client that is configured to sync the Görli Testnet. The Görli Testnet is the first proof-of-authority cross-client testnet. A testnet can be useful when developing dapps. If you’re a developer - this package can be very useful for you.",
   "type": "library",
@@ -19,9 +19,9 @@
       "8547:8547"
     ],
     "restart": "always",
-    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.15.tar.xz",
-    "hash": "/ipfs/QmW2u2mduMX3TB8RKfh11VQhpYaVN6ZgUmutSah256RgY2",
-    "size": 18561360,
+    "path": "goerli-geth.avado.dnp.dappnode.eth_10.4.16.tar.xz",
+    "hash": "/ipfs/QmS8KPiY88gshNLp4kTwfHcqTSNSFaSVerhS632WRUgcUY",
+    "size": 18946584,
     "environment": [
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   goerli-geth.avado.dnp.dappnode.eth:
-    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.15'
+    image: 'goerli-geth.avado.dnp.dappnode.eth:10.4.16'
     build: ./build
     volumes:
       - 'goerli:/goerli'

--- a/releases.json
+++ b/releases.json
@@ -82,5 +82,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 24 Aug 2021 07:44:11 GMT"
     }
+  },
+  "10.4.16": {
+    "hash": "/ipfs/QmWx3cBtKeUbxThzwPmim9vF13ApMTZq3WJZCoKd1LAcWh",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 29 Sep 2021 20:35:54 GMT"
+    }
   }
 }


### PR DESCRIPTION
Geth v1.10.9 is a maintenance release containing mostly bug fixes.

https://github.com/ethereum/go-ethereum/releases/tag/v1.10.9

Manifest hash : /ipfs/QmWx3cBtKeUbxThzwPmim9vF13ApMTZq3WJZCoKd1LAcWh  
http://my.dappnode/#/installer/%2Fipfs%2FQmWx3cBtKeUbxThzwPmim9vF13ApMTZq3WJZCoKd1LAcWh